### PR TITLE
"unknown" in order causing issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = {
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
     "import/order": ["error", {
-      "groups": ["builtin", "external", "unknown", "internal", "parent", "sibling", "index"]
+      "groups": ["builtin", "external", "internal", "parent", "sibling", "index"]
     }]
   }
 }


### PR DESCRIPTION
Looks like "unknown" isn't supported, even though the docs show it is
```
 error  Incorrect configuration of the rule: Unknown type `"unknown"`  import/order
```
https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md